### PR TITLE
Add useFieldState hook

### DIFF
--- a/src/hooks/use-field-state.js
+++ b/src/hooks/use-field-state.js
@@ -1,0 +1,21 @@
+// @flow
+
+/**
+ * Module dependencies.
+ */
+
+import { useFormState } from 'context/form-state-context';
+
+/**
+ * Export `useFieldState`.
+ */
+
+export default function useFieldState(field: string) {
+  const { errors, meta, values } = useFormState();
+
+  return {
+    error: errors?.[field] ?? null,
+    meta: meta?.[field] ?? {},
+    value: values?.[field]
+  };
+}

--- a/src/hooks/use-field.js
+++ b/src/hooks/use-field.js
@@ -6,14 +6,14 @@
 
 import { useCallback, useEffect } from 'react';
 import { useFieldActions } from 'context/field-actions-context';
-import { useFormState } from 'context/form-state-context';
+import useFieldState from './use-field-state';
 
 /**
  * Export `useField`.
  */
 
 export default function useField(field: string) {
-  const { errors, meta, values } = useFormState();
+  const { error, meta, value } = useFieldState(field);
   const {
     blurField,
     focusField,
@@ -38,11 +38,11 @@ export default function useField(field: string) {
   }, [field, focusField]);
 
   return {
-    error: errors?.[field] ?? null,
-    meta: meta?.[field] ?? {},
+    error,
+    meta,
     onBlur,
     onChange,
     onFocus,
-    value: values?.[field]
+    value
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@
 export { default as FormProvider } from './components/form-provider';
 export { default as useField } from './hooks/use-field';
 export { useFieldActions } from './context/field-actions-context';
+export { default as useFieldState } from './hooks/use-field-state';
 export { default as useForm } from './hooks/use-form';
 export { useFormActions } from './context/form-actions-context';
 export { useFormState } from './context/form-state-context';

--- a/test/src/hooks/use-field-state.test.js
+++ b/test/src/hooks/use-field-state.test.js
@@ -1,0 +1,68 @@
+/**
+ * Module dependencies.
+ */
+
+import { FormStateContext } from 'context/form-state-context';
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+import useFieldState from 'hooks/use-field-state';
+
+/**
+ * `useFieldState` hook tests.
+ */
+
+describe('useFieldState', () => {
+  it('should return the field value', () => {
+    const state = {
+      values: { foo: 'bar' }
+    };
+
+    const Wrapper = ({ children }) => (
+      <FormStateContext.Provider value={state}>
+        {children}
+      </FormStateContext.Provider>
+    );
+
+    const { result } = renderHook(() => useFieldState('foo'), {
+      wrapper: Wrapper
+    });
+
+    expect(result.current.value).toBe('bar');
+  });
+
+  it('should return the field error', () => {
+    const state = {
+      errors: { foo: 'bar' }
+    };
+
+    const Wrapper = ({ children }) => (
+      <FormStateContext.Provider value={state}>
+        {children}
+      </FormStateContext.Provider>
+    );
+
+    const { result } = renderHook(() => useFieldState('foo'), {
+      wrapper: Wrapper
+    });
+
+    expect(result.current.error).toBe('bar');
+  });
+
+  it('should return the field meta state', () => {
+    const state = {
+      meta: { foo: 'bar' }
+    };
+
+    const Wrapper = ({ children }) => (
+      <FormStateContext.Provider value={state}>
+        {children}
+      </FormStateContext.Provider>
+    );
+
+    const { result } = renderHook(() => useFieldState('foo'), {
+      wrapper: Wrapper
+    });
+
+    expect(result.current.meta).toBe('bar');
+  });
+});


### PR DESCRIPTION
This PR adds the `useFieldState` hook which returns the `value`, `error` and `meta` for the given field name.

This also updates the `useField` hook to use `useFieldState` internally.