### PR TITLE
Fix unhandled promise rejection on useForm hook

### DIFF
--- a/src/hooks/use-form.js
+++ b/src/hooks/use-form.js
@@ -338,21 +338,17 @@ export default function useForm(options: Options) {
     }
 
     onSubmit(state.values, { reset }).then(
-      result => {
+      () => {
         dispatch({
           payload: {},
           type: actionTypes.SUBMIT_SUCCESS
         });
-
-        return result;
       },
-      error => {
+      () => {
         dispatch({
           payload: {},
           type: actionTypes.SUBMIT_FAILURE
         });
-
-        return Promise.reject(error);
       }
     );
   }, [state, jsonSchema, onSubmit, reset]);


### PR DESCRIPTION
This PR fixes the `useForm` hook so that it no longer returns a rejected promise on the `onSubmit`
 rejection handler. This was necessary because this rejected promise is never handled which was resulting in a "Unhandled promise rejection" console warning. This was safe to remove because the resulting promise was never used, so returning a rejected promise was useless.