### PR TITLE
Fix useForm touched state not triggered by focus

### DIFF
--- a/src/hooks/use-form.js
+++ b/src/hooks/use-form.js
@@ -121,7 +121,8 @@ const metaReducer = (state, action) => {
         ...state,
         [payload.field]: {
           ...state[payload.field],
-          active: true
+          active: true,
+          touched: true
         }
       };
 

--- a/test/src/hooks/use-form.test.js
+++ b/test/src/hooks/use-form.test.js
@@ -76,7 +76,7 @@ describe('useForm hook', () => {
   });
 
   describe('focusField', () => {
-    it('should set the field to active', () => {
+    it('should set the field to active and touched', () => {
       const { result } = renderHook(() => useForm({
         jsonSchema: { type: 'object' },
         onSubmit: () => Promise.resolve()
@@ -86,7 +86,10 @@ describe('useForm hook', () => {
         result.current.fieldActions.focusField('foo');
       });
 
-      expect(result.current.state.meta.foo).toEqual({ active: true });
+      expect(result.current.state.meta.foo).toEqual({
+        active: true,
+        touched: true
+      });
     });
 
     it('should not validate the form', () => {


### PR DESCRIPTION
Once the user touched the input, touched was not being set to true.