### PR TITLE
Add dirty field state

### DIFF
--- a/src/hooks/use-form.js
+++ b/src/hooks/use-form.js
@@ -123,7 +123,17 @@ const metaReducer = (state, action) => {
         [payload.field]: {
           ...state[payload.field],
           active: false,
+          dirty: true,
           touched: true
+        }
+      };
+
+    case actionTypes.SET_FIELD_VALUE:
+      return {
+        ...state,
+        [payload.field]: {
+          ...state[payload.field],
+          dirty: true
         }
       };
 
@@ -133,7 +143,7 @@ const metaReducer = (state, action) => {
         [payload.field]: {
           ...state[payload.field],
           active: true,
-          touched: true
+          dirty: true
         }
       };
 
@@ -152,6 +162,7 @@ const metaReducer = (state, action) => {
         ...result,
         [key]: {
           ...state?.[key],
+          dirty: true,
           touched: true
         }
       }), {});
@@ -162,6 +173,7 @@ const metaReducer = (state, action) => {
         [key]: {
           ...state?.[key],
           active: false,
+          dirty: false,
           touched: false
         }
       }), {});

--- a/test/src/hooks/use-form.test.js
+++ b/test/src/hooks/use-form.test.js
@@ -39,7 +39,7 @@ describe('useForm hook', () => {
   });
 
   describe('blurField', () => {
-    it('should set the field to inactive and touched', () => {
+    it('should set the field to inactive, touched and dirty', () => {
       const { result } = renderHook(() => useForm({
         jsonSchema: { type: 'object' },
         onSubmit: () => {}
@@ -51,6 +51,7 @@ describe('useForm hook', () => {
 
       expect(result.current.state.fields.meta.foo).toEqual({
         active: false,
+        dirty: true,
         touched: true
       });
     });
@@ -76,7 +77,7 @@ describe('useForm hook', () => {
   });
 
   describe('focusField', () => {
-    it('should set the field to active and touched', () => {
+    it('should set the field to active and dirty', () => {
       const { result } = renderHook(() => useForm({
         jsonSchema: { type: 'object' },
         onSubmit: () => {}
@@ -88,7 +89,7 @@ describe('useForm hook', () => {
 
       expect(result.current.state.fields.meta.foo).toEqual({
         active: true,
-        touched: true
+        dirty: true
       });
     });
 
@@ -213,7 +214,7 @@ describe('useForm hook', () => {
       expect(result.current.state.fields.errors).toEqual({});
     });
 
-    it('should set all fields to inactive and untouched', () => {
+    it('should set all fields to inactive, untouched and pristine', () => {
       const { result } = renderHook(() => useForm({
         jsonSchema: { type: 'object' },
         onSubmit: () => {}
@@ -228,6 +229,7 @@ describe('useForm hook', () => {
       expect(result.current.state.fields.meta).toEqual({
         foo: {
           active: false,
+          dirty: false,
           touched: false
         }
       });
@@ -349,7 +351,7 @@ describe('useForm hook', () => {
       expect(result.current.state.fields.values).toEqual({ foo: 'bar' });
     });
 
-    it('should set all fields to touched', async () => {
+    it('should set all fields to touched and dirty', async () => {
       const { result, waitForNextUpdate } = renderHook(() => useForm({
         jsonSchema: { type: 'object' },
         onSubmit: () => {}
@@ -364,6 +366,7 @@ describe('useForm hook', () => {
 
       expect(result.current.state.fields.meta).toEqual({
         foo: expect.objectContaining({
+          dirty: true,
           touched: true
         })
       });


### PR DESCRIPTION
This PR adds the `dirty` field state. This indicates if an input as been interacted with.

This PR also fixes the `touched` field state, so that it is only set to `true` on the blur event.