### PR TITLE
Add validations for maxItems and minItems

### DIFF
--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -40,9 +40,11 @@ function getPropertyName(error: Object): string {
 
 function getErrorArgs(error) {
   switch (error.keyword) {
+    case 'maxItems':
     case 'maxLength':
       return { max: error.params.limit };
 
+    case 'minItems':
     case 'minLength':
       return { min: error.params.limit };
 

--- a/test/src/utils/validate.test.js
+++ b/test/src/utils/validate.test.js
@@ -108,4 +108,44 @@ describe('validate', () => {
       }
     });
   });
+
+  it('should return errors with the `maxItems` rule and `max` argument when there are too many items', () => {
+    const result = validate({
+      properties: {
+        foo: {
+          maxItems: 1,
+          type: 'array'
+        }
+      }
+    }, {
+      foo: [1, 2]
+    });
+
+    expect(result).toEqual({
+      foo: {
+        args: { max: 1 },
+        rule: 'maxItems'
+      }
+    });
+  });
+
+  it('should return errors with the `minItems` rule and `min` argument when there are not enough items', () => {
+    const result = validate({
+      properties: {
+        foo: {
+          minItems: 2,
+          type: 'array'
+        }
+      }
+    }, {
+      foo: [1]
+    });
+
+    expect(result).toEqual({
+      foo: {
+        args: { min: 2 },
+        rule: 'minItems'
+      }
+    });
+  });
 });


### PR DESCRIPTION
This PR updates the `validate` utility to add support for the `maxItems` and `minItems` keywords.