### PR TITLE
Add validations for maxProperties and minProperties

### DIFF
--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -42,10 +42,12 @@ function getErrorArgs(error) {
   switch (error.keyword) {
     case 'maxItems':
     case 'maxLength':
+    case 'maxProperties':
       return { max: error.params.limit };
 
     case 'minItems':
     case 'minLength':
+    case 'minProperties':
       return { min: error.params.limit };
 
     default:

--- a/test/src/utils/validate.test.js
+++ b/test/src/utils/validate.test.js
@@ -148,4 +148,49 @@ describe('validate', () => {
       }
     });
   });
+
+  it('should return errors with the `maxProperties` rule', () => {
+    const result = validate({
+      properties: {
+        foo: {
+          maxProperties: 1,
+          type: 'object'
+        }
+      }
+    }, {
+      foo: {
+        bar: 'qux',
+        baz: 'biz'
+      }
+    });
+
+    expect(result).toEqual({
+      foo: {
+        args: { max: 1 },
+        rule: 'maxProperties'
+      }
+    });
+  });
+
+  it('should return errors with the `minProperties` rule', () => {
+    const result = validate({
+      properties: {
+        foo: {
+          minProperties: 2,
+          type: 'string'
+        }
+      }
+    }, {
+      foo: {
+        bar: 'qux'
+      }
+    });
+
+    expect(result).toEqual({
+      foo: {
+        args: { min: 2 },
+        rule: 'minProperties'
+      }
+    });
+  });
 });


### PR DESCRIPTION
This PR updates the `validate` utility to add support for the `maxProperties` and `minProperties` keywords.