### PR TITLE
Fix flow configuration

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,7 +1,6 @@
 [ignore]
-.*/dist/.*
-
-[libs]
+<PROJECT_ROOT>/coverage/.*
+<PROJECT_ROOT>/dist/.*
 
 [options]
 esproposal.class_instance_fields=enable


### PR DESCRIPTION
This PR fixes the `[ignore]` section of the flow configuration, so that only the `dist` folder on the
project root is ignored, not other `dist` folders, like inside `node_modules`. This also adds the `coverage` folder to the ignored paths.