### PR TITLE
Add validation options to validate custom formats

### DIFF
--- a/src/components/form-provider.js
+++ b/src/components/form-provider.js
@@ -7,6 +7,7 @@
 import { FieldActionsContext } from 'context/field-actions-context';
 import { FormActionsContext } from 'context/form-actions-context';
 import { FormStateContext } from 'context/form-state-context';
+import type { ValidationOptions } from 'utils/validate';
 import React, { type Node } from 'react';
 import useForm, { type Action, type FormState, type Submit } from 'hooks/use-form';
 
@@ -23,7 +24,8 @@ type Props = {
   jsonSchema: Object,
   onFormValuesChanged?: (formState: Object) => void,
   onSubmit: Submit,
-  stateReducer?: (state: FormState, action: Action) => FormState
+  stateReducer?: (state: FormState, action: Action) => FormState,
+  validationOptions?: ValidationOptions
 };
 
 /**
@@ -37,7 +39,8 @@ const FormProvider = (props: Props): Node => {
     jsonSchema,
     onFormValuesChanged,
     onSubmit,
-    stateReducer
+    stateReducer,
+    validationOptions
   } = props;
 
   const {
@@ -49,7 +52,8 @@ const FormProvider = (props: Props): Node => {
     jsonSchema,
     onSubmit,
     onValuesChanged: onFormValuesChanged,
-    stateReducer
+    stateReducer,
+    validationOptions
   });
 
   return (

--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -4,7 +4,25 @@
  * Module dependencies.
  */
 
+import { merge } from 'lodash';
 import Ajv from 'ajv';
+
+/**
+ * Export `ValidationOptions` type.
+ */
+
+export type ValidationOptions = {
+  coerceTypes?: boolean | 'array',
+  format?: boolean | 'fast' | 'full',
+  formats?: Object,
+  logger?: Function,
+  nullable?: boolean,
+  removeAdditional?: boolean | 'all' | 'failing',
+  schemaId?: String,
+  uniqueItems?: boolean,
+  unknownFormats?: boolean | Array<string> | 'ignore' | Object,
+  useDefaults?: boolean | 'empty' | 'shared'
+};
 
 /**
  * Export `FieldErrorType` type.
@@ -81,8 +99,8 @@ function parseValidationErrors(validationErrors) {
  * Export `validate`.
  */
 
-export default function validate(schema: Object, values: Object) {
-  const ajv = new Ajv({ $data: true, allErrors: true });
+export default function validate(schema: Object, values: Object, validateOptions: ValidationOptions) {
+  const ajv = new Ajv(merge({}, validateOptions, { $data: true, allErrors: true }));
 
   if (ajv.validate(schema, values)) {
     return {};

--- a/test/src/hooks/use-form.test.js
+++ b/test/src/hooks/use-form.test.js
@@ -454,5 +454,42 @@ describe('useForm hook', () => {
       expect(result.current.state.fields.values.foo).toEqual('biz');
       expect(result.current.state.fields.values.bar).toEqual('bar');
     });
+
+    it('should validate the field with custom format', () => {
+      const { result } = renderHook(() => useForm({
+        initialValues: {
+          bar: '123',
+          foo: '123'
+        },
+        jsonSchema: {
+          properties: {
+            bar: {
+              format: 'bar',
+              type: 'string'
+            },
+            foo: {
+              format: 'foo',
+              type: 'string'
+            }
+          },
+          type: 'object'
+        },
+        onSubmit: () => {},
+        validationOptions: {
+          formats: {
+            bar: value => !isNaN(Number(value)),
+            foo: () => false
+          }
+        }
+      }));
+
+      act(() => {
+        result.current.formActions.submit();
+      });
+
+      expect(result.current.state.fields.errors).toEqual(expect.objectContaining({
+        foo: expect.any(Object)
+      }));
+    });
   });
 });


### PR DESCRIPTION
This PR adds a `validationOptions` property to `useForm` hook to validate custom formats with ajv.