### PR TITLE
Update validation to support custom keywords

### DIFF
--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -15,6 +15,7 @@ export type ValidationOptions = {
   coerceTypes?: boolean | 'array',
   format?: boolean | 'fast' | 'full',
   formats?: Object,
+  keywords?: Object,
   logger?: Function,
   nullable?: boolean,
   removeAdditional?: boolean | 'all' | 'failing',
@@ -99,8 +100,17 @@ function parseValidationErrors(validationErrors) {
  * Export `validate`.
  */
 
-export default function validate(schema: Object, values: Object, validateOptions: ValidationOptions) {
-  const ajv = new Ajv(merge({}, validateOptions, { $data: true, allErrors: true }));
+export default function validate(schema: Object, values: Object, validateOptions?: ValidationOptions) {
+  const { keywords, ...restOptions } = validateOptions ?? {};
+  const ajv = new Ajv(merge({}, restOptions, { $data: true, allErrors: true }));
+
+  // TODO: Remove this when ajv adds support for passing keywords in the contructor.
+  // https://github.com/epoberezkin/ajv/issues/1136
+  if (keywords) {
+    for (const [keyword, config] of Object.entries(keywords)) {
+      ajv.addKeyword(keyword, config);
+    }
+  }
 
   if (ajv.validate(schema, values)) {
     return {};

--- a/test/src/hooks/use-form.test.js
+++ b/test/src/hooks/use-form.test.js
@@ -487,9 +487,56 @@ describe('useForm hook', () => {
         result.current.formActions.submit();
       });
 
-      expect(result.current.state.fields.errors).toEqual(expect.objectContaining({
-        foo: expect.any(Object)
+      expect(result.current.state.fields.errors).toEqual({
+        foo: {
+          rule: 'format'
+        }
+      });
+    });
+
+    it('should validate with custom keywords', () => {
+      const { result } = renderHook(() => useForm({
+        initialValues: {
+          bar: '123',
+          foo: '123'
+        },
+        jsonSchema: {
+          properties: {
+            bar: {
+              isBar: true,
+              type: 'string'
+            },
+            foo: {
+              isFoo: true,
+              type: 'string'
+            }
+          },
+          type: 'object'
+        },
+        onSubmit: () => {},
+        validationOptions: {
+          keywords: {
+            isBar: {
+              type: 'string',
+              validate: () => true
+            },
+            isFoo: {
+              type: 'string',
+              validate: () => false
+            }
+          }
+        }
       }));
+
+      act(() => {
+        result.current.formActions.submit();
+      });
+
+      expect(result.current.state.fields.errors).toEqual({
+        foo: {
+          rule: 'isFoo'
+        }
+      });
     });
   });
 });

--- a/test/src/utils/validate.test.js
+++ b/test/src/utils/validate.test.js
@@ -233,4 +233,70 @@ describe('validate', () => {
       }
     });
   });
+
+  it('should validate with custom format', () => {
+    const result = validate({
+      properties: {
+        bar: {
+          format: 'bar',
+          type: 'string'
+        },
+        foo: {
+          format: 'foo',
+          type: 'string'
+        }
+      },
+      type: 'object'
+    }, {
+      bar: '123',
+      foo: '123'
+    }, {
+      formats: {
+        bar: () => true,
+        foo: () => false
+      }
+    });
+
+    expect(result).toEqual({
+      foo: {
+        rule: 'format'
+      }
+    });
+  });
+
+  it('should validate with custom keywords', () => {
+    const result = validate({
+      properties: {
+        bar: {
+          isBar: true,
+          type: 'string'
+        },
+        foo: {
+          isFoo: true,
+          type: 'string'
+        }
+      },
+      type: 'object'
+    }, {
+      bar: '123',
+      foo: '123'
+    }, {
+      keywords: {
+        isBar: {
+          type: 'string',
+          validate: () => true
+        },
+        isFoo: {
+          type: 'string',
+          validate: () => false
+        }
+      }
+    });
+
+    expect(result).toEqual({
+      foo: {
+        rule: 'isFoo'
+      }
+    });
+  });
 });


### PR DESCRIPTION
This updates the validation options to support passing custom keywords.

Example:

```js
const jsonSchema = {
  properties: {
    foo: {
      myCustomKeyword: ...
    }
  }
};

const validationOptions = {
  keywords: {
    myCustomKeyword: {
      validate: () => {
        // ...
      }
    }
  }
};

<FormProvider
  jsonSchema={jsonSchema}
  onSubmit={onSubmit}
  validationOptions={validationOptions}
>
```

See `ajv`'s documentation for more information about custom keywords: https://github.com/epoberezkin/ajv/blob/master/CUSTOM.md