### PR TITLE
Add validate option

### DIFF
--- a/src/components/form-provider.js
+++ b/src/components/form-provider.js
@@ -7,7 +7,7 @@
 import { FieldActionsContext } from 'context/field-actions-context';
 import { FormActionsContext } from 'context/form-actions-context';
 import { FormStateContext } from 'context/form-state-context';
-import type { ValidationOptions } from 'utils/validate';
+import type { Validate, ValidationOptions } from 'utils/validate';
 import React, { type Node } from 'react';
 import useForm, { type Action, type FormState, type Submit } from 'hooks/use-form';
 
@@ -25,6 +25,7 @@ type Props = {
   onFormValuesChanged?: (formState: Object) => void,
   onSubmit: Submit,
   stateReducer?: (state: FormState, action: Action) => FormState,
+  validate?: Validate,
   validationOptions?: ValidationOptions
 };
 
@@ -40,6 +41,7 @@ const FormProvider = (props: Props): Node => {
     onFormValuesChanged,
     onSubmit,
     stateReducer,
+    validate,
     validationOptions
   } = props;
 
@@ -53,6 +55,7 @@ const FormProvider = (props: Props): Node => {
     onSubmit,
     onValuesChanged: onFormValuesChanged,
     stateReducer,
+    validate,
     validationOptions
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@
  */
 
 export { default as FormProvider } from './components/form-provider';
+export { getErrorPath, parseValidationErrors } from './utils/validate';
 export { default as useField } from './hooks/use-field';
 export { useFieldActions } from './context/field-actions-context';
 export { default as useFieldState } from './hooks/use-field-state';

--- a/test/src/hooks/use-form.test.js
+++ b/test/src/hooks/use-form.test.js
@@ -607,4 +607,23 @@ describe('useForm hook', () => {
       expect(result.current.state.meta.touched).toBe(true);
     });
   });
+
+  describe('custom validate', () => {
+    it('should be called when a field value changes', () => {
+      const validate = jest.fn(() => ({}));
+      const jsonSchema = { type: 'object' };
+      const { result } = renderHook(() => useForm({
+        jsonSchema,
+        onSubmit: () => {},
+        validate,
+        validationOptions: 'qux'
+      }));
+
+      act(() => {
+        result.current.fieldActions.setFieldValue('foo', 'bar');
+      });
+
+      expect(validate).toHaveBeenCalledWith(jsonSchema, { foo: 'bar' }, 'qux');
+    });
+  });
 });


### PR DESCRIPTION
This adds the `validate` option that makes it possible to override the internal `validate` function.

Parts of the `validation` function were also exported, to easily create custom validation functions with similar functionality.