### PR TITLE
Fix form errors reducer

### DIFF
--- a/src/hooks/use-form.js
+++ b/src/hooks/use-form.js
@@ -213,7 +213,7 @@ function errorsReducer(options: ErrorOptions) {
     case actionTypes.SET_FIELD_VALUE:
     case actionTypes.REGISTER_FIELD:
     case actionTypes.SUBMIT_START:
-      return validate(values);
+      return validate(values) ?? {};
 
     case actionTypes.RESET:
       return {};

--- a/test/src/hooks/use-form.test.js
+++ b/test/src/hooks/use-form.test.js
@@ -625,5 +625,19 @@ describe('useForm hook', () => {
 
       expect(validate).toHaveBeenCalledWith(jsonSchema, { foo: 'bar' }, 'qux');
     });
+
+    it('should set errors to an empty object when validate returns undefined', () => {
+      const { result } = renderHook(() => useForm({
+        jsonSchema: { type: 'object' },
+        onSubmit: () => {},
+        validate: () => {}
+      }));
+
+      act(() => {
+        result.current.fieldActions.setFieldValue('foo', 'bar');
+      });
+
+      expect(result.current.state.fields.errors).toEqual({});
+    });
   });
 });


### PR DESCRIPTION
This makes the errors reducer fallback to an empty object when the `validate` function returns `null` or `undefined`.