### PR TITLE
Fix initial form state to include initial errors

### DIFF
--- a/src/hooks/use-form.js
+++ b/src/hooks/use-form.js
@@ -301,6 +301,32 @@ const formReducer = (validate: Object => FieldErrors, stateReducer: (state: Form
 };
 
 /**
+ * Initialize state.
+ */
+
+function initializeState(validate: Validate) {
+  return (initialValues: Object): FormState => {
+    const errors = validate(initialValues) ?? {};
+
+    return {
+      fields: {
+        errors,
+        meta: {},
+        values: initialValues
+      },
+      isSubmitting: false,
+      meta: {
+        active: false,
+        dirty: false,
+        hasErrors: Object.entries(errors).length > 0,
+        touched: false
+      },
+      submitStatus: 'idle'
+    };
+  };
+}
+
+/**
  * `Options` type.
  */
 
@@ -332,21 +358,8 @@ export default function useForm(options: Options) {
   const validateValues = values => validate(jsonSchema, values, validationOptions);
   const [state, dispatch] = useReducer(
     formReducer(validateValues, stateReducer),
-    {
-      fields: {
-        errors: {},
-        meta: {},
-        values: initialValues
-      },
-      isSubmitting: false,
-      meta: {
-        active: false,
-        dirty: false,
-        hasErrors: false,
-        touched: false
-      },
-      submitStatus: 'idle'
-    }
+    initialValues,
+    initializeState(validateValues)
   );
 
   const setFieldValue = useCallback((field: string, value: any) => {


### PR DESCRIPTION
This PR fixes the initial state of the form, so that `validate` is called with the `initialValues`, to initialize the form with errors if there are any.

This is necessary for forms that disable the submit button when there are errors. Since `meta.hasErrors` was always starting as `false`, the submit button was enabled at the first render.