### PR TITLE
Update reset action to optionally receive new initial values

### DIFF
--- a/src/hooks/use-form.js
+++ b/src/hooks/use-form.js
@@ -390,8 +390,15 @@ export default function useForm(options: Options) {
     });
   }, []);
 
-  const reset = useCallback(() => {
-    dispatch({
+  const reset = useCallback((formValues?: Object) => {
+    if (formValues) {
+      return dispatch({
+        payload: { initialValues: formValues },
+        type: actionTypes.RESET
+      });
+    }
+
+    return dispatch({
       payload: { initialValues },
       type: actionTypes.RESET
     });

--- a/test/src/hooks/use-form.test.js
+++ b/test/src/hooks/use-form.test.js
@@ -230,6 +230,25 @@ describe('useForm hook', () => {
       expect(result.current.state.fields.values).toEqual({ foo: 'bar' });
     });
 
+    it('should set the received values as initial values', () => {
+      const { result } = renderHook(() => useForm({
+        jsonSchema: { type: 'object' },
+        onSubmit: () => {}
+      }));
+
+      act(() => {
+        result.current.formActions.reset({
+          baz: 'qux',
+          foo: 'bar'
+        });
+      });
+
+      expect(result.current.state.fields.values).toEqual({
+        baz: 'qux',
+        foo: 'bar'
+      });
+    });
+
     it('should clear the form errors', () => {
       const { result } = renderHook(() => useForm({
         jsonSchema: {


### PR DESCRIPTION
This MR allows to pass to the reset action the values that we want to set as initial values.