### PR TITLE
Update setFieldValue with update function

### DIFF
--- a/src/hooks/use-form.js
+++ b/src/hooks/use-form.js
@@ -96,11 +96,20 @@ const valuesReducer = (state, action) => {
   const { payload, type } = action;
 
   switch (type) {
-    case actionTypes.SET_FIELD_VALUE:
+    case actionTypes.SET_FIELD_VALUE: {
+      let newValue;
+
+      if (typeof payload.value === 'function') {
+        newValue = payload.value(state[payload.field]);
+      } else {
+        newValue = payload.value;
+      }
+
       return {
         ...state,
-        [payload.field]: payload.value
+        [payload.field]: newValue
       };
+    }
 
     case actionTypes.REGISTER_FIELD:
       return {

--- a/test/src/hooks/use-form.test.js
+++ b/test/src/hooks/use-form.test.js
@@ -337,6 +337,27 @@ describe('useForm hook', () => {
 
       expect(result.current.state.fields.errors).toHaveProperty('foo');
     });
+
+    it('should call the passed callback with the current field value and update it to the returned value', () => {
+      const callback = jest.fn(() => 'qux');
+      const { result } = renderHook(() => useForm({
+        initialValues: { foo: 'bar' },
+        jsonSchema: {
+          properties: {
+            foo: { type: 'string' }
+          },
+          type: 'object'
+        },
+        onSubmit: () => {}
+      }));
+
+      act(() => {
+        result.current.fieldActions.setFieldValue('foo', callback);
+      });
+
+      expect(callback).toHaveBeenCalledWith('bar');
+      expect(result.current.state.fields.values).toEqual({ foo: 'qux' });
+    });
   });
 
   describe('submit', () => {


### PR DESCRIPTION
This PR updates the `setFieldValue` action in the `useForm` hook to accept an update function, that is called with the field's current value.

This allows us to compute the new field value from the previous value when using `useField`'s `onChange`. Example:

```js
function Gallery() {
  // `value` is an array of images.
  const { onChange, value } = useField('gallery');

  const addImages = useCallback(newImages => {
    // Using the update function we don't need to make this `useCallback` depend on `value`
    // and we guarantee that we always use the latest value to compute the new value.
    onChange(images => images.concat(newImages));
  }, []);

  // Etc...
}