### PR TITLE
Fix error paths of nested properties

### DIFF
--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -66,6 +66,10 @@ export function getErrorPath(error: ValidationError): string {
     key = error.instancePath.substring(2, error.instancePath.length - 2);
   }
 
+  key = key
+    .replace(/\/(\d+)(?=\/|$)/g, '[$1]')
+    .replace(/\//g, '.');
+
   switch (error.keyword) {
     case 'required':
       return `${key ? `${key}.` : ''}${error.params.missingProperty}`;

--- a/test/src/utils/validate.test.js
+++ b/test/src/utils/validate.test.js
@@ -245,6 +245,88 @@ describe('validate', () => {
     });
   });
 
+  it('should validate nested properties', () => {
+    const result = validate({
+      properties: {
+        foo: {
+          properties: {
+            bar: {
+              properties: {
+                qux: { type: 'string' }
+              },
+              type: 'object'
+            }
+          },
+          type: 'object'
+        }
+      },
+      type: 'object'
+    }, {
+      foo: {
+        bar: { qux: 1 }
+      }
+    });
+
+    expect(result).toEqual({
+      'foo.bar.qux': {
+        rule: 'type'
+      }
+    });
+  });
+
+  it('should validate arrays', () => {
+    const result = validate({
+      properties: {
+        foo: {
+          items: {
+            properties: {
+              bar: {
+                items: { type: 'string' },
+                type: 'array'
+              }
+            },
+            type: 'object'
+          },
+          type: 'array'
+        }
+      },
+      type: 'object'
+    }, {
+      foo: [{
+        bar: [1]
+      }]
+    });
+
+    expect(result).toEqual({
+      'foo[0].bar[0]': {
+        rule: 'type'
+      }
+    });
+  });
+
+  it('should validate arrays with arrays', () => {
+    const result = validate({
+      properties: {
+        foo: {
+          items: {
+            items: { type: 'string' },
+            type: 'array'
+          },
+          type: 'array'
+        }
+      },
+      type: 'object'
+    }, {
+      foo: [[1]]
+    });
+
+    expect(result).toEqual({
+      'foo[0][0]': {
+        rule: 'type'
+      }
+    });
+  });
+
   it('should validate with custom format', () => {
     const result = validate({
       properties: {


### PR DESCRIPTION
This PR fixes the `validate` function to return property paths in dot notation.

This was necessary because `ajv` changed these paths to use `/` instead of `.`.