### PR TITLE
Update validation to always return error arguments

### DIFF
--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -101,7 +101,7 @@ function getErrorArgs(error: ValidationError) {
       return { min: error.params.limit };
 
     default:
-      return;
+      return error.params;
   }
 }
 

--- a/test/src/hooks/use-form.test.js
+++ b/test/src/hooks/use-form.test.js
@@ -600,6 +600,7 @@ describe('useForm hook', () => {
 
       expect(result.current.state.fields.errors).toEqual({
         foo: {
+          args: { format: 'foo' },
           rule: 'format'
         }
       });
@@ -644,6 +645,7 @@ describe('useForm hook', () => {
 
       expect(result.current.state.fields.errors).toEqual({
         foo: {
+          args: {},
           rule: 'isFoo'
         }
       });

--- a/test/src/utils/validate.test.js
+++ b/test/src/utils/validate.test.js
@@ -30,9 +30,11 @@ describe('validate', () => {
 
     expect(result).toEqual({
       foo: {
+        args: { type: 'string' },
         rule: 'type'
       },
       'foo-bar': {
+        args: { type: 'string' },
         rule: 'type'
       }
     });
@@ -49,6 +51,7 @@ describe('validate', () => {
 
     expect(result).toEqual({
       foo: {
+        args: { missingProperty: 'foo' },
         rule: 'required'
       }
     });
@@ -65,6 +68,7 @@ describe('validate', () => {
 
     expect(result).toEqual({
       foo: {
+        args: { additionalProperty: 'foo' },
         rule: 'additionalProperties'
       }
     });
@@ -269,6 +273,7 @@ describe('validate', () => {
 
     expect(result).toEqual({
       'foo.bar.qux': {
+        args: { type: 'string' },
         rule: 'type'
       }
     });
@@ -299,6 +304,7 @@ describe('validate', () => {
 
     expect(result).toEqual({
       'foo[0].bar[0]': {
+        args: { type: 'string' },
         rule: 'type'
       }
     });
@@ -322,6 +328,7 @@ describe('validate', () => {
 
     expect(result).toEqual({
       'foo[0][0]': {
+        args: { type: 'string' },
         rule: 'type'
       }
     });
@@ -352,6 +359,7 @@ describe('validate', () => {
 
     expect(result).toEqual({
       foo: {
+        args: { format: 'foo' },
         rule: 'format'
       }
     });
@@ -387,6 +395,7 @@ describe('validate', () => {
 
     expect(result).toEqual({
       foo: {
+        args: {},
         rule: 'isFoo'
       }
     });


### PR DESCRIPTION
This PR updates the validation to always return error arguments. This is necessary for keywords other than the ones already being handled.